### PR TITLE
Display model architecture version badge instead of size

### DIFF
--- a/src/components/ModelList.tsx
+++ b/src/components/ModelList.tsx
@@ -1,6 +1,6 @@
 // src/components/ModelList.tsx
 import { useCallback, useEffect, useRef } from 'react';
-import type { Model } from '../types';
+import type { Model, ArchitectureVersion } from '../types';
 import { t3kClient } from '../App';
 import {
   T3kSlimPlayer,
@@ -15,9 +15,8 @@ interface Props {
   models: Model[];
 }
 
-const SIZE_LABELS: Record<string, string> = {
-  'standard': 'Standard', 'lite': 'Lite',
-  'feather': 'Feather', 'nano': 'Nano', 'custom': 'Custom',
+const ARCHITECTURE_LABELS: Record<ArchitectureVersion, string> = {
+  '1': 'A1', '2': 'A2', 'custom': 'Custom',
 };
 
 const getExtension = (url: string) => url.split('.').pop()?.toLowerCase();
@@ -81,7 +80,7 @@ function ModelRow({ model }: ModelRowProps) {
     <div className="model-row">
       <div className="model-row-info">
         <span className="model-row-name">{model.name}</span>
-        <span className="badge">{SIZE_LABELS[model.size] ?? model.size}</span>
+        <span className="badge">{ARCHITECTURE_LABELS[model.architecture_version] ?? model.architecture_version}</span>
       </div>
       <div className="model-row-actions">
         {canPlay ? (

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,6 +112,9 @@ export interface Tone {
   url: string;
 }
 
+/** Neural model architecture version. 'custom' covers user-supplied architectures. */
+export type ArchitectureVersion = '1' | '2' | 'custom';
+
 export interface Model {
   id: number;
   created_at: string;
@@ -120,6 +123,7 @@ export interface Model {
   model_url: string;
   name: string;
   size: Size;
+  architecture_version: ArchitectureVersion;
   tone_id: number;
 }
 


### PR DESCRIPTION
Models now expose architecture_version ('1' | '2' | 'custom'); render it as an A1/A2/Custom badge in the model list.