### PR TITLE
Rename platform -> format to match API cutover

### DIFF
--- a/src/apps/FullApiApp.tsx
+++ b/src/apps/FullApiApp.tsx
@@ -268,7 +268,7 @@ export function FullApiApp() {
                   <p className="tone-detail-creator">by @{selectedTone.user.username}</p>
                 </div>
                 <div className="tone-detail-badges">
-                  <span className="badge badge--platform">{selectedTone.platform}</span>
+                  <span className="badge badge--format">{selectedTone.format}</span>
                   <span className="badge badge--gear">{selectedTone.gear}</span>
                   {!selectedTone.is_public && <span className="badge badge--private">Private</span>}
                 </div>

--- a/src/components/ToneCard.tsx
+++ b/src/components/ToneCard.tsx
@@ -8,7 +8,7 @@ interface Props {
   compact?: boolean;
 }
 
-const PLATFORM_LABELS: Record<string, string> = {
+const FORMAT_LABELS: Record<string, string> = {
   'nam': 'NAM', 'ir': 'IR', 'aida-x': 'AIDA-X',
   'aa-snapshot': 'Snapshot', 'proteus': 'Proteus',
 };
@@ -33,7 +33,7 @@ export function ToneCard({ tone, onClick, compact = false }: Props) {
           <p className="tone-card-desc">{tone.description}</p>
         )}
         <div className="tone-card-badges">
-          <span className="badge badge--platform">{PLATFORM_LABELS[tone.platform] ?? tone.platform}</span>
+          <span className="badge badge--format">{FORMAT_LABELS[tone.format] ?? tone.format}</span>
           <span className="badge badge--gear">{GEAR_LABELS[tone.gear] ?? tone.gear}</span>
           {!tone.is_public && <span className="badge badge--private">Private</span>}
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -129,7 +129,7 @@ button.tone-card:hover { border-color: var(--accent); box-shadow: 0 2px 8px rgba
 
 /* ─── Badges ─────────────────────────────────────────────────────────────────── */
 .badge { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 4px; background: var(--surface2); border: 1px solid var(--border); color: var(--text-2); text-transform: uppercase; letter-spacing: 0.04em; }
-.badge--platform { border-color: #93c5fd; color: #1d4ed8; background: rgba(37,99,235,0.07); }
+.badge--format { border-color: #93c5fd; color: #1d4ed8; background: rgba(37,99,235,0.07); }
 .badge--gear { border-color: #c4b5fd; color: #6d28d9; background: rgba(109,40,217,0.07); }
 .badge--private { border-color: var(--border); }
 

--- a/src/tone3000-client.ts
+++ b/src/tone3000-client.ts
@@ -83,19 +83,19 @@ function buildAuthorizeUrl(
  * catalog. After the user selects a tone, they're redirected back to your app
  * with an authorization code and the selected `tone_id`.
  *
- * Optional `options`: `gears` (underscore-separated, e.g. `amp_pedal`), `platform`
+ * Optional `options`: `gears` (underscore-separated, e.g. `amp_pedal`), `format`
  * (e.g. `nam`, `aida-x`), `architecture` (numeric), `menubar` (UI hint) — each is
  * forwarded as an authorize query param when set.
  */
 export async function startSelectFlow(
   publishableKey: string,
   redirectUri: string,
-  options?: { gears?: string; platform?: string; menubar?: boolean, loginHint?: string, architecture?: number }
+  options?: { gears?: string; format?: string; menubar?: boolean, loginHint?: string, architecture?: number }
 ): Promise<void> {
   const pkce = await buildPkceParams();
   const extra: Record<string, string> = { prompt: 'select_tone' };
   if (options?.gears) extra.gears = options.gears;
-  if (options?.platform) extra.platform = options.platform;
+  if (options?.format) extra.format = options.format;
   if (options?.menubar) extra.menubar = 'true';
   if (options?.architecture) extra.architecture = options.architecture.toString();
   if (options?.loginHint) extra.login_hint = options.loginHint;
@@ -108,13 +108,13 @@ export async function startSelectFlow(
  * Same as `startSelectFlow` but opens in a popup. The user stays on your app while
  * browsing TONE3000. When a tone is selected, the popup relays the result back via
  * `postMessage` or `BroadcastChannel` — handle it with `handleOAuthCallbackFromPopup`.
- * Supports the same optional `gears`, `platform`, `architecture`, and `menubar`
+ * Supports the same optional `gears`, `format`, `architecture`, and `menubar`
  * as `startSelectFlow`.
  */
 export async function startSelectFlowPopup(
   publishableKey: string,
   redirectUri: string,
-  options?: { gears?: string; platform?: string; menubar?: boolean, loginHint?: string, architecture?: number }
+  options?: { gears?: string; format?: string; menubar?: boolean, loginHint?: string, architecture?: number }
 ): Promise<Window | null> {
   // Set before window.open so the popup inherits this flag via sessionStorage copy;
   // remove it from the parent immediately so only the popup retains it.
@@ -122,7 +122,7 @@ export async function startSelectFlowPopup(
   const pkce = await buildPkceParams();
   const extra: Record<string, string> = { prompt: 'select_tone' };
   if (options?.gears) extra.gears = options.gears;
-  if (options?.platform) extra.platform = options.platform;
+  if (options?.format) extra.format = options.format;
   if (options?.menubar) extra.menubar = 'true';
   if (options?.architecture) extra.architecture = options.architecture.toString();
   if (options?.loginHint) extra.login_hint = options.loginHint;
@@ -204,22 +204,22 @@ export async function handleOAuthCallbackFromPopup(
  *
  * If the tone is private or has been deleted, TONE3000 shows an error page
  * where the user can browse for a replacement. In that case, the `tone_id` in
- * the callback may differ from the one you requested. Any `gears`, `platform`,
+ * the callback may differ from the one you requested. Any `gears`, `format`,
  * or `architecture` filters you pass are applied to that replacement browse view.
  *
  * @param gears - Optional underscore-separated gear filter (e.g. 'amp_full-rig')
- * @param platform - Optional platform filter (e.g. 'nam', 'aida-x')
+ * @param format - Optional format filter (e.g. 'nam', 'aida-x')
  */
 export async function startLoadToneFlow(
   publishableKey: string,
   redirectUri: string,
   toneId: number | string,
-  options?: { gears?: string; platform?: string; menubar?: boolean, loginHint?: string, architecture?: number }
+  options?: { gears?: string; format?: string; menubar?: boolean, loginHint?: string, architecture?: number }
 ): Promise<void> {
   const pkce = await buildPkceParams();
   const extra: Record<string, string> = { prompt: 'load_tone', tone_id: String(toneId) };
   if (options?.gears) extra.gears = options.gears;
-  if (options?.platform) extra.platform = options.platform;
+  if (options?.format) extra.format = options.format;
   if (options?.menubar) extra.menubar = 'true';
   if (options?.architecture) extra.architecture = options.architecture.toString();
   if (options?.loginHint) extra.login_hint = options.loginHint;
@@ -231,14 +231,14 @@ export async function startLoadToneFlow(
  *
  * Same as `startLoadToneFlow` but opens in a popup. When the flow completes, the
  * popup relays the result back via `postMessage` or `BroadcastChannel` — handle it
- * with `handleOAuthCallbackFromPopup`. Any `gears`, `platform`, or `architecture`
+ * with `handleOAuthCallbackFromPopup`. Any `gears`, `format`, or `architecture`
  * filters you pass are applied if the user needs to browse for a replacement tone.
  */
 export async function startLoadToneFlowPopup(
   publishableKey: string,
   redirectUri: string,
   toneId: number | string,
-  options?: { gears?: string; platform?: string; menubar?: boolean, loginHint?: string, architecture?: number }
+  options?: { gears?: string; format?: string; menubar?: boolean, loginHint?: string, architecture?: number }
 ): Promise<Window | null> {
   // Set before window.open so the popup inherits this flag via sessionStorage copy;
   // remove it from the parent immediately so only the popup retains it.
@@ -246,7 +246,7 @@ export async function startLoadToneFlowPopup(
   const pkce = await buildPkceParams();
   const extra: Record<string, string> = { prompt: 'load_tone', tone_id: String(toneId) };
   if (options?.gears) extra.gears = options.gears;
-  if (options?.platform) extra.platform = options.platform;
+  if (options?.format) extra.format = options.format;
   if (options?.menubar) extra.menubar = 'true';
   if (options?.architecture) extra.architecture = options.architecture.toString();
   if (options?.loginHint) extra.login_hint = options.loginHint;
@@ -263,19 +263,19 @@ export async function startLoadToneFlowPopup(
 /**
  * **Load Tone Flow (Popup, model_id variant)** — Open TONE3000 in a popup to
  * authenticate and load a tone resolved from a specific model. Optional
- * `gears`, `platform`, or `architecture` apply if the user browses for a replacement.
+ * `gears`, `format`, or `architecture` apply if the user browses for a replacement.
  */
 export async function startLoadToneFlowPopupByModelId(
   publishableKey: string,
   redirectUri: string,
   modelId: number | string,
-  options?: { gears?: string; platform?: string; menubar?: boolean, loginHint?: string, architecture?: number }
+  options?: { gears?: string; format?: string; menubar?: boolean, loginHint?: string, architecture?: number }
 ): Promise<Window | null> {
   sessionStorage.setItem('t3k_popup_mode', '1');
   const pkce = await buildPkceParams();
   const extra: Record<string, string> = { prompt: 'load_tone', model_id: String(modelId) };
   if (options?.gears) extra.gears = options.gears;
-  if (options?.platform) extra.platform = options.platform;
+  if (options?.format) extra.format = options.format;
   if (options?.menubar) extra.menubar = 'true';
   if (options?.architecture) extra.architecture = options.architecture.toString();
   if (options?.loginHint) extra.login_hint = options.loginHint;

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export enum Gear {
   Ir = 'ir',
 }
 
-export enum Platform {
+export enum Format {
   Nam = 'nam',
   Ir = 'ir',
   AidaX = 'aida-x',
@@ -101,7 +101,7 @@ export interface Tone {
   images: string[] | null;
   is_public: boolean | null;
   links: string[] | null;
-  platform: Platform;
+  format: Format;
   license: License;
   sizes: Size[];
   makes: Make[];


### PR DESCRIPTION
The API now emits `format` (not `platform`) in responses and no longer includes `platform`, so `tone.platform` was undefined at runtime. Rename the Tone field and its UI reads, the badge class, and the request-side filter option across the select/load flows. `format` is canonical; `platform` remains accepted by the API as a deprecated request alias.